### PR TITLE
update some dependencies

### DIFF
--- a/camera/read_camera.py
+++ b/camera/read_camera.py
@@ -1,7 +1,10 @@
 import argparse
 import cv2
 import redis
-import urlparse
+try:
+    import urlparse
+except ImportError:
+    import urllib.parse as urlparse
 
 class Webcam:
     def __init__(self, infile=0, fps=15.0):

--- a/camera/requirements.txt
+++ b/camera/requirements.txt
@@ -1,2 +1,2 @@
-opencv-python<=4.0.1.23
+opencv-python>4.0,<4.1
 redis==3.2.1

--- a/camera/requirements.txt
+++ b/camera/requirements.txt
@@ -1,2 +1,2 @@
-opencv-python==4.0.1.23
+opencv-python<=4.0.1.23
 redis==3.2.1


### PR DESCRIPTION
use urllib.parse if urlparse is not available
update requirements to accept a higher version of opencv-python
I tested with: Version: 4.0.1.24

